### PR TITLE
Add support for charts navigation

### DIFF
--- a/src/index.story.js
+++ b/src/index.story.js
@@ -4,6 +4,7 @@ import isBefore from "date-fns/isBefore";
 import isEqual from "date-fns/isEqual";
 import { storiesOf } from "@storybook/react";
 import ReactFrappeChart from "./index";
+import { action } from '@storybook/addon-actions';
 
 const config = {
   colors: ["#21ba45", "#98d85b"],
@@ -48,7 +49,7 @@ storiesOf("Line", module)
           labels: labels,
           datasets: [{ values: [18, 40, 30, 35, 8, 52, 17, 4] }]
         }}
-        onDataSelect={(e) => window.alert(JSON.stringify(e))}
+        onDataSelect={action('Point clicked')}
         {...config}
       />
     </div>

--- a/src/index.story.js
+++ b/src/index.story.js
@@ -39,6 +39,19 @@ storiesOf("Line", module)
         {...config}
       />
     </div>
+  ))
+  .add("Navigation Event", () => (
+    <div style={{ width: "500px" }}>
+      <ReactFrappeChart
+        type="line"
+        data={{
+          labels: labels,
+          datasets: [{ values: [18, 40, 30, 35, 8, 52, 17, 4] }]
+        }}
+        onDataSelect={(e) => window.alert(JSON.stringify(e))}
+        {...config}
+      />
+    </div>
   ));
 
 storiesOf("Bar", module)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -62,21 +62,21 @@ type Props = {
 export default function ReactFrappeChart(props: Props) {
   const ref = React.useRef<HTMLDivElement>(null);
   const chart = React.useRef<any>(null);
-  const {onDataSelect} = props;
+  const { onDataSelect } = props;
 
   React.useEffect(() => {
-    chart.current = new Chart(
-      ref.current, 
-      { 
-        isNavigable: onDataSelect!==undefined, 
-        ...props 
-      }
-    );
+    chart.current = new Chart(ref.current, {
+      isNavigable: onDataSelect !== undefined,
+      ...props
+    });
     if (onDataSelect) {
-      chart.current.parent.addEventListener('data-select', (e: SelectEvent&React.SyntheticEvent) => {
-        e.preventDefault();
-        onDataSelect(e);
-      });
+      chart.current.parent.addEventListener(
+        "data-select",
+        (e: SelectEvent & React.SyntheticEvent) => {
+          e.preventDefault();
+          onDataSelect(e);
+        }
+      );
     }
   }, []);
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,8 +23,7 @@ type ChartData = {
   end?: Date;
 };
 
-// Event contains label and value of current datapoint
-interface SelectEvent {
+type SelectEvent = {
   label: string;
   values: number[];
   index: number;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,6 +23,13 @@ type ChartData = {
   end?: Date;
 };
 
+// Event contains label and value of current datapoint
+interface SelectEvent {
+  label: string;
+  values: number[];
+  index: number;
+};
+
 type Props = {
   title?: string;
   type?: ChartType;
@@ -50,14 +57,28 @@ type Props = {
   };
   isNavigable?: boolean;
   maxSlices?: number;
+  onDataSelect?: (event: SelectEvent) => void;
 };
 
 export default function ReactFrappeChart(props: Props) {
   const ref = React.useRef<HTMLDivElement>(null);
   const chart = React.useRef<any>(null);
+  const {onDataSelect} = props;
 
   React.useEffect(() => {
-    chart.current = new Chart(ref.current, { ...props });
+    chart.current = new Chart(
+      ref.current, 
+      { 
+        isNavigable: onDataSelect!==undefined, 
+        ...props 
+      }
+    );
+    if (onDataSelect) {
+      chart.current.parent.addEventListener('data-select', (e: SelectEvent&React.SyntheticEvent) => {
+        e.preventDefault();
+        onDataSelect(e);
+      });
+    }
   }, []);
 
   React.useEffect(() => {


### PR DESCRIPTION
Give access to listen navigation events from Frappe by passing `onDataSelect` callback as optional property attribute: https://frappe.io/charts/docs/update_state/navigation