### PR TITLE
add a 'returnReference' to keep the chart reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ export default function MyChart(props) {
         labels: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"],
         datasets: [{ values: [18, 40, 30, 35, 8, 52, 17, 4] }]
       }}
-      returnReference={ ref => {/* do something with the chart's React DOM reference, i.e. save to some variable, so later can do <variable>.export() to export the cart */} }
+      chartRef={ ref => {/* do something with the chart's React DOM reference, i.e. save to some variable, so later can do <variable>.export() to export the cart */} }
     />
   );
 }

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ export default function MyChart(props) {
         labels: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"],
         datasets: [{ values: [18, 40, 30, 35, 8, 52, 17, 4] }]
       }}
+      returnReference={ ref => {/* do something with the chart's React DOM reference, i.e. save to some variable, so later can do <variable>.export() to export the cart */} }
     />
   );
 }

--- a/build/index.d.ts
+++ b/build/index.d.ts
@@ -47,7 +47,9 @@ declare type Props = {
     isNavigable?: boolean;
     maxSlices?: number;
     onDataSelect?: (event: SelectEvent) => void;
-    chartRef?: (instance: Object) => void;
+    chartRef?: {
+        current: any;
+    };
 };
 export default function ReactFrappeChart(props: Props): JSX.Element;
 export {};

--- a/build/index.d.ts
+++ b/build/index.d.ts
@@ -47,7 +47,7 @@ declare type Props = {
     isNavigable?: boolean;
     maxSlices?: number;
     onDataSelect?: (event: SelectEvent) => void;
-    returnReference?: (instance: Object) => void;
+    chartRef?: (instance: Object) => void;
 };
 export default function ReactFrappeChart(props: Props): JSX.Element;
 export {};

--- a/build/index.d.ts
+++ b/build/index.d.ts
@@ -47,6 +47,7 @@ declare type Props = {
     isNavigable?: boolean;
     maxSlices?: number;
     onDataSelect?: (event: SelectEvent) => void;
+    returnReference?: (instance: Object) => void;
 };
 export default function ReactFrappeChart(props: Props): JSX.Element;
 export {};

--- a/build/index.js
+++ b/build/index.js
@@ -2,8 +2,8 @@ import React from "react";
 import { Chart } from "frappe-charts/dist/frappe-charts.min.esm";
 export default function ReactFrappeChart(props) {
     const ref = React.useRef(null);
-    const chart = React.useRef(null);
-    const { onDataSelect, chartRef } = props;
+    const chart = props.chartRef || React.useRef(null);
+    const { onDataSelect } = props;
     React.useEffect(() => {
         chart.current = new Chart(ref.current, Object.assign({ isNavigable: onDataSelect !== undefined }, props));
         if (onDataSelect) {
@@ -12,15 +12,9 @@ export default function ReactFrappeChart(props) {
                 onDataSelect(e);
             });
         }
-        if (chartRef) {
-            chartRef(chart);
-        }
-    }, []);
+    }, [chart]);
     React.useEffect(() => {
         chart.current.update(props.data);
-        if (chartRef) {
-            chartRef(chart);
-        }
     }, [props.data]);
     return React.createElement("div", { ref: ref });
 }

--- a/build/index.js
+++ b/build/index.js
@@ -3,7 +3,7 @@ import { Chart } from "frappe-charts/dist/frappe-charts.min.esm";
 export default function ReactFrappeChart(props) {
     const ref = React.useRef(null);
     const chart = React.useRef(null);
-    const { onDataSelect } = props;
+    const { onDataSelect, returnReference } = props;
     React.useEffect(() => {
         chart.current = new Chart(ref.current, Object.assign({ isNavigable: onDataSelect !== undefined }, props));
         if (onDataSelect) {
@@ -12,9 +12,15 @@ export default function ReactFrappeChart(props) {
                 onDataSelect(e);
             });
         }
+        if (returnReference) {
+            returnReference(chart);
+        }
     }, []);
     React.useEffect(() => {
         chart.current.update(props.data);
+        if (returnReference) {
+            returnReference(chart);
+        }
     }, [props.data]);
     return React.createElement("div", { ref: ref });
 }

--- a/build/index.js
+++ b/build/index.js
@@ -3,7 +3,7 @@ import { Chart } from "frappe-charts/dist/frappe-charts.min.esm";
 export default function ReactFrappeChart(props) {
     const ref = React.useRef(null);
     const chart = React.useRef(null);
-    const { onDataSelect, returnReference } = props;
+    const { onDataSelect, chartRef } = props;
     React.useEffect(() => {
         chart.current = new Chart(ref.current, Object.assign({ isNavigable: onDataSelect !== undefined }, props));
         if (onDataSelect) {
@@ -12,14 +12,14 @@ export default function ReactFrappeChart(props) {
                 onDataSelect(e);
             });
         }
-        if (returnReference) {
-            returnReference(chart);
+        if (chartRef) {
+            chartRef(chart);
         }
     }, []);
     React.useEffect(() => {
         chart.current.update(props.data);
-        if (returnReference) {
-            returnReference(chart);
+        if (chartRef) {
+            chartRef(chart);
         }
     }, [props.data]);
     return React.createElement("div", { ref: ref });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -57,13 +57,13 @@ type Props = {
   isNavigable?: boolean;
   maxSlices?: number;
   onDataSelect?: (event: SelectEvent) => void;
-  returnReference?: (instance: Object) => void;
+  chartRef?: (instance: Object) => void;
 };
 
 export default function ReactFrappeChart(props: Props) {
   const ref = React.useRef<HTMLDivElement>(null);
   const chart = React.useRef<any>(null);
-  const { onDataSelect, returnReference } = props;
+  const { onDataSelect, chartRef } = props;
 
   React.useEffect(() => {
     chart.current = new Chart(ref.current, {
@@ -79,15 +79,15 @@ export default function ReactFrappeChart(props: Props) {
         }
       );
     }
-    if (returnReference) {
-      returnReference(chart)
+    if (chartRef) {
+      chartRef(chart)
     }
   }, []);
 
   React.useEffect(() => {
     chart.current.update(props.data);
-    if (returnReference) {
-      returnReference(chart)
+    if (chartRef) {
+      chartRef(chart)
     }
   }, [props.data]);
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -57,12 +57,13 @@ type Props = {
   isNavigable?: boolean;
   maxSlices?: number;
   onDataSelect?: (event: SelectEvent) => void;
+  returnReference?: (instance: Object) => void;
 };
 
 export default function ReactFrappeChart(props: Props) {
   const ref = React.useRef<HTMLDivElement>(null);
   const chart = React.useRef<any>(null);
-  const { onDataSelect } = props;
+  const { onDataSelect, returnReference } = props;
 
   React.useEffect(() => {
     chart.current = new Chart(ref.current, {
@@ -78,10 +79,16 @@ export default function ReactFrappeChart(props: Props) {
         }
       );
     }
+    if (returnReference) {
+      returnReference(chart)
+    }
   }, []);
 
   React.useEffect(() => {
     chart.current.update(props.data);
+    if (returnReference) {
+      returnReference(chart)
+    }
   }, [props.data]);
 
   return <div ref={ref} />;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -57,13 +57,15 @@ type Props = {
   isNavigable?: boolean;
   maxSlices?: number;
   onDataSelect?: (event: SelectEvent) => void;
-  chartRef?: (instance: Object) => void;
+  chartRef?: {
+    current: any
+  };
 };
 
 export default function ReactFrappeChart(props: Props) {
   const ref = React.useRef<HTMLDivElement>(null);
-  const chart = React.useRef<any>(null);
-  const { onDataSelect, chartRef } = props;
+  const chart = props.chartRef || React.useRef<any>(null);
+  const { onDataSelect } = props;
 
   React.useEffect(() => {
     chart.current = new Chart(ref.current, {
@@ -79,16 +81,10 @@ export default function ReactFrappeChart(props: Props) {
         }
       );
     }
-    if (chartRef) {
-      chartRef(chart)
-    }
-  }, []);
+  }, [chart]);
 
   React.useEffect(() => {
     chart.current.update(props.data);
-    if (chartRef) {
-      chartRef(chart)
-    }
   }, [props.data]);
 
   return <div ref={ref} />;


### PR DESCRIPTION
add a 'returnReference' to keep the chart reference for future manipulation, i.e. export()

returnReference is a function which will be called and will receive the *chart* as a parameter, so we can store it in a upper component