### PR TITLE
Make all axis, bar and line properties optional

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -36,23 +36,23 @@ type Props = {
   height?: number;
   colors?: Array<string>;
   axisOptions?: {
-    xAxisMode: AxisMode;
-    yAxisMode: AxisMode;
-    xIsSeries: 0 | 1;
+    xAxisMode?: AxisMode;
+    yAxisMode?: AxisMode;
+    xIsSeries?: 0 | 1;
   };
   barOptions?: {
-    spaceRatio: number;
-    stacked: 0 | 1;
-    height: number;
-    depth: number;
+    spaceRatio?: number;
+    stacked?: 0 | 1;
+    height?: number;
+    depth?: number;
   };
   lineOptions?: {
-    dotSize: number;
-    hideLine: 0 | 1;
-    hideDots: 0 | 1;
-    heatline: 0 | 1;
-    regionFill: number;
-    areaFill: number;
+    dotSize?: number;
+    hideLine?: 0 | 1;
+    hideDots?: 0 | 1;
+    heatline?: 0 | 1;
+    regionFill?: number;
+    areaFill?: number;
   };
   isNavigable?: boolean;
   maxSlices?: number;


### PR DESCRIPTION
As [per the official frappe documentation](https://frappe.io/charts/docs/basic/basic_chart#responsiveness), `axisOptions`, `barOptions` and `lineOptions` may be specified on their own.