### PR TITLE
Support bundlers, adding `module` to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "heatmap chart"
   ],
   "main": "./build/index.js",
+  "module": "./build/index.js",
   "scripts": {
     "start": "start-storybook -p 3030 -s public",
     "clean": "rm -rf build",


### PR DESCRIPTION
Next.js throws an exception otherwise, stating that `import` statements cannot be executed from non-ESM packages.