### PR TITLE
Upgrade frappe-charts dependency to 1.5.2, and set as a minimum version instead of a fixed version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7175,9 +7175,9 @@
       }
     },
     "frappe-charts": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/frappe-charts/-/frappe-charts-1.2.4.tgz",
-      "integrity": "sha512-aTTOwZ99PTNbBPbujyZnUFwnbcBUksDol8FKXEiUkY7CYKZdvHaRzVrXsw2r48B05xdn+HFMEKfOl5X2zqMYsg=="
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/frappe-charts/-/frappe-charts-1.5.2.tgz",
+      "integrity": "sha512-e//lw86slhJ560YenTqUCHSV9pJVYn1p2fPGu4OGFSIjWcWQ1ydhSqjTIoJu1OhU/HPCGUhlWGmTq3Ln2BS5IA=="
     },
     "fresh": {
       "version": "0.5.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "frappe-charts": "1.2.4"
+    "frappe-charts": "^1.5.2"
   },
   "peerDependencies": {
     "react": ">= 16.8.0",


### PR DESCRIPTION
IMO there's no reason why the `frappe-charts` dependency should not follow the most recent minor versions.