### PR TITLE
Add support for animate, valuesOverPOints, truncateLegends and toolttipOptions

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,7 +23,13 @@ type SelectEvent = {
   index: number;
 };
 
+type TooltipOptions = {
+  formatTooltipX?: (value: number) => any;
+  formatTooltipY?: (value: number) => any;
+};
+
 type Props = {
+  animate?: 0 | 1;
   title?: string;
   type?: ChartType;
   data: ChartData;
@@ -50,7 +56,10 @@ type Props = {
   };
   isNavigable?: boolean;
   maxSlices?: number;
+  truncateLegends?: 0 | 1;
+  tooltipOptions?: TooltipOptions;
   onDataSelect?: (event: SelectEvent) => void;
+  valuesOverPoints?: 0 | 1;
 };
 
 const ReactFrappeChart = forwardRef((props: Props, parentRef) => {

--- a/src/playground.story.js
+++ b/src/playground.story.js
@@ -1,6 +1,6 @@
 import React, { useRef } from "react";
 import { storiesOf } from "@storybook/react";
-import { number, text, array, select } from "@storybook/addon-knobs";
+import { number, text, array, select, boolean } from "@storybook/addon-knobs";
 import ReactFrappeChart from "./index";
 
 storiesOf("Playground", module).add("Default", () => {
@@ -11,6 +11,10 @@ storiesOf("Playground", module).add("Default", () => {
       chartRef.current.export();
     }
   };
+
+  const formatDefault = (value) => value;
+
+  const formatAddText = (value) => `"added text" ${value}`;
 
   return (
     <div style={{ width: "500px" }}>
@@ -72,6 +76,9 @@ storiesOf("Playground", module).add("Default", () => {
             "green"
           ),
         ]}
+        animate={select("animate", [0, 1], 1)}
+        valuesOverPoints={select("valuesOverPoints", [0, 1], 0)}
+        truncateLegends={select("truncateLegends", [0, 1], 0)}
         lineOptions={{
           dotSize: number("dotSize", 4),
           hideLine: select("hideLine", [0, 1], 0),
@@ -93,6 +100,14 @@ storiesOf("Playground", module).add("Default", () => {
         }}
         maxSlices={number("maxSlices", 10)}
         height={number("Height", 300)}
+        tooltipOptions={{
+          formatTooltipX: boolean("formatTooltipX", false)
+            ? formatAddText
+            : formatDefault,
+          formatTooltipY: boolean("formatTooltipY", false)
+            ? formatAddText
+            : formatDefault,
+        }}
       />
       <button onClick={exportChart} type="button">
         Export


### PR DESCRIPTION
I noticed that frappe supports these options but they weren't available on `ReactFrappeChart` so this PR adds those props to the component. Updated the playground with knobs for all the new options as well.

https://frappe.io/charts/docs/reference/configuration (side note: the documentation shows the tooltip options with capitals for some reason `TooltipOptions` but looking at the source/demo code shows that it's tooltipOptions and I tested that it is working in the playground.

![image](https://user-images.githubusercontent.com/5158502/101697637-0662a700-3a2d-11eb-9ba1-47756d0f650f.png)