### PR TITLE
Add spline option to types

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -47,6 +47,7 @@ type Props = {
     heatline?: 0 | 1;
     regionFill?: number;
     areaFill?: number;
+    spline?: 0 | 1;
   };
   isNavigable?: boolean;
   maxSlices?: number;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/10457719/116796339-85b24f00-aa90-11eb-91a7-ce5b4cf341da.png)

I noticed react-frappe-charts didn't support the spline option here: https://frappe.io/charts/docs/basic/trends_regions

With this change, typescript users can use the spline option.