### PR TITLE
Fixing Failed to execute 'removeChild' on 'Node' error

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -56,6 +56,7 @@ type Props = {
 const ReactFrappeChart = forwardRef((props: Props, parentRef) => {
   const ref = React.useRef<HTMLDivElement>(null);
   const chart = React.useRef<any>(null);
+  const initialRender = React.useRef<boolean>(true);
   const { onDataSelect } = props;
 
   useImperativeHandle(parentRef, () => ({
@@ -80,6 +81,10 @@ const ReactFrappeChart = forwardRef((props: Props, parentRef) => {
   }, []);
 
   React.useEffect(() => {
+    if (initialRender.current) {
+      initialRender.current = false;
+      return;
+    }
     chart.current.update(props.data);
   }, [props.data]);
 


### PR DESCRIPTION
Hi

First of all, thank you for creating this wrapper for Frappe Charts, we really appreciate your effort <3

I noticed that there was an error log when I used it, although it doesn't block the project from running (unless it is in dev mode)

I found that in the initial render, the following `useEffect` is being called

```js
  React.useEffect(() => {
    chart.current.update(props.data);
  }, [props.data]);
```

I added a blocker for this `useEffect` in first render only, which solves the issue

