### PR TITLE
Add yMarkers and yRegions

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,6 +15,7 @@ type ChartData = {
   dataPoints?: { [x: string]: number };
   start?: Date;
   end?: Date;
+  yMarkers?: Array<{ label: string; value: number; options?: object; }>;
 };
 
 type SelectEvent = {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,6 +16,12 @@ type ChartData = {
   start?: Date;
   end?: Date;
   yMarkers?: Array<{ label: string; value: number; options?: object; }>;
+  yRegions?: Array<{
+    label: string;
+    start: number;
+    end: number;
+    options?: object;
+  }>;
 };
 
 type SelectEvent = {


### PR DESCRIPTION
Add yMarkers and yRegions to ChartData so they can be used without type errors.

I added the optional 'options' fields but did not constrain them to a particular type. Let me know if there is a better type to use here.

https://frappe.io/charts/docs/reference/configuration
From the frappe charts docs:
<img width="881" alt="Screen Shot 2022-11-20 at 1 36 52 PM" src="https://user-images.githubusercontent.com/5257160/202927453-56b4b233-b42c-439b-acda-f3817e485e37.png">
