### PR TITLE
Add donut chart type

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,7 @@
 import React, { useImperativeHandle, forwardRef } from "react";
 import { Chart } from "frappe-charts/dist/frappe-charts.min.esm";
 
-type ChartType = "line" | "bar" | "axis-mixed" | "pie" | "percentage" | "heatmap";
+type ChartType = "line" | "bar" | "axis-mixed" | "pie" | "donut" | "percentage" | "heatmap";
 
 type AxisMode = "span" | "tick";
 


### PR DESCRIPTION
frappe-charts supports "donut" as a chart type, but react-frappe-charts didn't have it listed as an option. This PR adds "donut" as an option for `ChartType`.

[Frappe Charts docs: Donut chart](https://frappe.io/charts/docs/basic/aggr_sliced_diags#donut-chart)